### PR TITLE
Bug fixes and new widgets

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -358,6 +358,7 @@ Note on creating multiple system instances. Add following rules to your CSS:
 }
 
 .als-menu-maps-select {
+	white-space: nowrap;
 	text-overflow: ellipsis;
 	width: 100%; /* Hack for older browsers */
 }
@@ -511,7 +512,7 @@ Note on creating multiple system instances. Add following rules to your CSS:
 	width: 100%;
 }
 
-.als-layer-menu[data-hidden="1"] {
+.als-layer-menu[data-hidden="0"] {
 	border-bottom: var(--border) !important;
 }
 
@@ -604,10 +605,6 @@ Note on creating multiple system instances. Add following rules to your CSS:
 
 /* Checkbox */
 .als-checkbox-wrapper {
-	display: inline-block;
-	display: flex;
-	align-items: center;
-	vertical-align: middle;
 	width: 1.2rem;
 	flex: none;
 }
@@ -618,11 +615,9 @@ Note on creating multiple system instances. Add following rules to your CSS:
 }
 
 .als-checkbox-wrapper > .ri {
+	display: table-cell !important;
 	min-width: 1rem !important;
 	width: 1rem !important;
-	height: 1rem !important;
-	min-height: 1rem !important;
-	max-height: 1rem !important;
 	font-size: 0.9rem !important;
 	font-weight: 700;
 	margin: 0 !important;
@@ -637,16 +632,23 @@ Note on creating multiple system instances. Add following rules to your CSS:
 }
 
 .als-radio-group-wrapper > .als-widget-row { /* Parent .als-widget-row overrides display of this one, so we gotta restore it */
-	display: block;
-	display: flex;
+	display: table;
+	vertical-align: middle;
 	padding-left: 1rem;
 }
 
-.als-radio-group-wrapper > .als-label {
-	margin-bottom: 0.5rem;
+.als-radio-group-wrapper .als-checkbox-wrapper {
+	display: table-cell;
+	vertical-align: middle;
+}
+
+.als-radio-group-wrapper .als-checkbox-wrapper + .als-label {
+	vertical-align: middle;
 }
 
 .als-radio-group-wrapper input + .ri {
+	display: table-cell !important;
+	vertical-align: middle;
 	border-radius: 100% !important;
 }
 
@@ -687,6 +689,44 @@ Note on creating multiple system instances. Add following rules to your CSS:
 
 .als-number > *:last-child {
 	border-right: var(--border);
+}
+
+/* Single button */
+.als-buttons-wrapper {
+	display: table;
+	width: 100%;
+}
+
+.als-buttons-wrapper .als-button-base {
+	display: table-cell;
+	height: 2rem;
+}
+
+/* Buttons group */
+.als-buttons-group-wrapper {
+	display: block;
+	display: flex !important;
+	flex-flow: row wrap !important;
+	justify-content: stretch;
+	padding: 0;
+}
+
+.als-buttons-group-wrapper .als-widget-row {
+	width: 100%;
+	flex: 1 1 6rem;
+	height: auto !important;
+	align-self: stretch;
+}
+
+.als-buttons-group-wrapper .als-input {
+	width: 100%;
+	max-width: 100% !important;
+	height: 100% !important;
+	box-sizing: border-box;
+}
+
+.als-buttons-group-wrapper .als-icon-button-container {
+	flex: 0 0 2rem;
 }
 
 /* Divider */
@@ -783,7 +823,6 @@ Note on creating multiple system instances. Add following rules to your CSS:
 
 .als-simple-label-wrapper {
 	width: 100% !important;
-	width: 1.2rem !important;
 }
 
 .als-simple-label {

--- a/css/base.css
+++ b/css/base.css
@@ -358,6 +358,7 @@ Note on creating multiple system instances. Add following rules to your CSS:
 }
 
 .als-menu-maps-select {
+	text-overflow: ellipsis;
 	width: 100%; /* Hack for older browsers */
 }
 
@@ -603,13 +604,20 @@ Note on creating multiple system instances. Add following rules to your CSS:
 
 /* Checkbox */
 .als-checkbox-wrapper {
-	width: 1rem !important;
+	display: inline-block;
+	display: flex;
+	align-items: center;
+	vertical-align: middle;
+	width: 1.2rem;
 	flex: none;
 }
 
+.als-checkbox-wrapper > input:checked + .ri {
+	color: var(--text-color) !important;
+	transition: color 0.2s, background 0.2s;
+}
+
 .als-checkbox-wrapper > .ri {
-	display: inline-block !important;
-	vertical-align: middle !important;
 	min-width: 1rem !important;
 	width: 1rem !important;
 	height: 1rem !important;
@@ -619,6 +627,31 @@ Note on creating multiple system instances. Add following rules to your CSS:
 	font-weight: 700;
 	margin: 0 !important;
 	padding: 0 !important;
+	color: transparent !important;
+	transition: color 0.2s, background 0.2s;
+}
+
+/* Radio buttons */
+.als-radio-group-wrapper {
+	display: block;
+}
+
+.als-radio-group-wrapper > .als-widget-row { /* Parent .als-widget-row overrides display of this one, so we gotta restore it */
+	display: block;
+	display: flex;
+	padding-left: 1rem;
+}
+
+.als-radio-group-wrapper > .als-label {
+	margin-bottom: 0.5rem;
+}
+
+.als-radio-group-wrapper input + .ri {
+	border-radius: 100% !important;
+}
+
+.als-radio-label-wrapper > .ri {
+	margin-left: 1rem;
 }
 
 /* Number input */
@@ -628,6 +661,7 @@ Note on creating multiple system instances. Add following rules to your CSS:
 }
 
 .als-number > input {
+	vertical-align: middle;
 	width: 4rem; /* Hack for older browsers */
 	flex: 1 1;
 }
@@ -636,7 +670,7 @@ Note on creating multiple system instances. Add following rules to your CSS:
 	width: 2rem; /* Hack for older browsers */
 }
 
-.als-number > div {
+.als-number > .ri {
 	min-width: 1.2rem;
 	max-width: 1.2rem;
 	min-height: 1.2rem;
@@ -749,6 +783,7 @@ Note on creating multiple system instances. Add following rules to your CSS:
 
 .als-simple-label-wrapper {
 	width: 100% !important;
+	width: 1.2rem !important;
 }
 
 .als-simple-label {

--- a/css/base.css
+++ b/css/base.css
@@ -85,7 +85,7 @@ body {
 
 .leaflet-left .leaflet-control,
 .leaflet-right .leaflet-control,
-.button-base, input[type="button"], select, .ri {
+.als-button-base, select, .ri {
 	margin: 0;
 	border-radius: 0 !important;
 	color: var(--text-color);
@@ -113,11 +113,11 @@ body {
 	margin-bottom: 0;
 }
 
-.button-base {
+.als-button-base {
 	min-height: 2rem;
 }
 
-.button-base, input[type="button"], select, .ri, .leaflet-control > a {
+.als-button-base, select, .ri {
 	display: inline-block;
 	vertical-align: middle;
 	box-sizing: border-box;
@@ -131,14 +131,14 @@ body {
 	user-select: none;
 }
 
-.not-mobile .button-base:hover, .not-mobile input[type="button"]:hover, .not-mobile select:hover, .not-mobile .ri:hover, .not-mobile .leaflet-control > a:hover, .jscolor-btn-close:hover {
+.not-mobile .als-button-base:hover, .not-mobile select:hover, .not-mobile .ri:hover, .jscolor-btn-close:hover {
 	background: var(--hover-bg);
 	transition: background 0.2s;
 }
 
 
 /* Setting background to select:active will cause bugs in older browsers, so we don't use it */
-.button-base:active, input[type="button"]:active, .ri:active, .leaflet-control > a:active, .jscolor-btn-close:active {
+.als-button-base:active, .ri:active, .jscolor-btn-close:active {
 	background: var(--fixed-element-selected-bg) !important;
 	transition: background 0.2s;
 }
@@ -151,7 +151,7 @@ body {
 }
 
 /* Revert button in settings */
-.revert-button {
+.als-revert-button {
 	width: 1.5rem;
 	height: 1.5rem;
 	font-size: 0.7rem;
@@ -168,7 +168,7 @@ input, select {
 	border: var(--border);
 }
 
-.invalid-input {
+.als-invalid-input {
 	background: var(--error-bg);
 	border: 1px solid var(--error-border);
 }
@@ -230,7 +230,7 @@ select > * {
 }
 
 /* Icon button container */
-.icon-button-container > .ri {
+.als-icon-button-container > .ri {
 	width: auto;
 	max-width: 100%;
 }
@@ -333,7 +333,7 @@ Note on creating multiple system instances. Add following rules to your CSS:
 	overflow-x: hidden;
 }
 
-.controls-row-set {
+.als-items-row {
 	display: table; /* Hack for older browsers */
 	table-layout: fixed;
 	display: flex;
@@ -344,7 +344,7 @@ Note on creating multiple system instances. Add following rules to your CSS:
 	border-bottom: var(--border);
 }
 
-.controls-row-set > * {
+.als-items-row > * {
 	display: table-cell !important;
 	display: flex !important;
 	border: none !important;
@@ -353,7 +353,7 @@ Note on creating multiple system instances. Add following rules to your CSS:
 	flex: 1;
 }
 
-.controls-row-set > *:last-child {
+.als-items-row > *:last-child {
 	border-right: none;
 }
 
@@ -506,35 +506,35 @@ Note on creating multiple system instances. Add following rules to your CSS:
 }
 
 /* Layers */
-.layer-container {
+.als-layer-container {
 	width: 100%;
 }
 
-.layer-menu[data-hidden="1"] {
+.als-layer-menu[data-hidden="1"] {
 	border-bottom: var(--border) !important;
 }
 
-.layer-container > .controls-row-set {
+.als-layer-container > .als-items-row {
 	border-bottom: var(--border) !important;
 	transition: background 0.3s;
 }
 
-.not-mobile .layer-container > .controls-row-set:hover {
+.not-mobile .als-layer-container > .als-items-row:hover {
 	background: var(--hover-bg);
 	transition: background 0.3s;
 }
 
-.layer-container[data-is-selected = "1"] > .controls-row-set,
-.not-mobile .layer-container[data-is-selected = "1"] > .controls-row-set:hover {
+.als-layer-container[data-is-selected = "1"] > .als-items-row,
+.not-mobile .als-layer-container[data-is-selected = "1"] > .als-items-row:hover {
 	background: var(--fixed-element-selected-bg);
 	transition: background 0.3s;
 }
 
-.layer-container > .controls-row-set {
+.als-layer-container > .als-items-row {
 	border: none;
 }
 
-.layer-label {
+.als-layer-label {
 	display: inline-block;
 	vertical-align: middle;
 	display: flex;
@@ -546,15 +546,15 @@ Note on creating multiple system instances. Add following rules to your CSS:
 	overflow: hidden;
 }
 
-.layer-label[contenteditable = "true"] {
+.als-layer-label[contenteditable = "true"] {
 	text-decoration: underline;
 }
 
-.layer-handle {
+.als-layer-handle {
 	cursor: move;
 }
 
-.layer-menu {
+.als-layer-menu {
 	display: block;
 	width: 100%;
 	border: none;

--- a/css/base.css
+++ b/css/base.css
@@ -607,11 +607,16 @@ Note on creating multiple system instances. Add following rules to your CSS:
 	flex: none;
 }
 
-.als-checkbox-wrapper > * {
+.als-checkbox-wrapper > .ri {
 	display: inline-block !important;
 	vertical-align: middle !important;
 	min-width: 1rem !important;
 	width: 1rem !important;
+	height: 1rem !important;
+	min-height: 1rem !important;
+	max-height: 1rem !important;
+	font-size: 0.9rem !important;
+	font-weight: 700;
 	margin: 0 !important;
 	padding: 0 !important;
 }
@@ -637,6 +642,7 @@ Note on creating multiple system instances. Add following rules to your CSS:
 	min-height: 1.2rem;
 	height: 1.2rem;
 	font-size: 1rem;
+	font-weight: 700;
 	line-height: 1.2rem;
 	padding: 0 !important;
 }

--- a/js/LeafletAdvancedLayerSystem/ALSControlZoom.js
+++ b/js/LeafletAdvancedLayerSystem/ALSControlZoom.js
@@ -5,13 +5,13 @@ L.ALS.ControlZoom = L.Control.extend({
 
 	onAdd: function (map) {
 		let minusButton = document.createElement("i");
-		minusButton.className = "button-base icon-button ri ri-subtract-line";
+		minusButton.className = "als-button-base icon-button ri ri-subtract-line";
 		minusButton.addEventListener("click", () => {
 			map.zoomOut();
 		});
 
 		let plusButton = document.createElement("i");
-		plusButton.className = "button-base icon-button ri ri-add-line";
+		plusButton.className = "als-button-base icon-button ri ri-add-line";
 		plusButton.addEventListener("click", () => {
 			map.zoomIn();
 		});

--- a/js/LeafletAdvancedLayerSystem/Helpers.js
+++ b/js/LeafletAdvancedLayerSystem/Helpers.js
@@ -120,10 +120,10 @@ L.ALS.Helpers = {
 			let newValue, callback;
 			if (e.getAttribute(dataHidden) === "1") {
 				newValue = "0";
-				callback = onHideCallback;
+				callback = onShowCallback;
 			} else {
 				newValue = "1";
-				callback = onShowCallback;
+				callback = onHideCallback;
 			}
 			e.setAttribute(dataHidden, newValue);
 
@@ -241,7 +241,7 @@ L.ALS.Helpers = {
 				// Taken from https://attacomsian.com/blog/javascript-base64-encode-decode
 				btoa(encodeURIComponent(string).replace(/%([0-9A-F]{2})/g,
 					function (match, p1) {
-						return String.fromCharCode('0x' + p1);
+						return String.fromCharCode("0x" + p1);
 					})), false);
 			return;
 		}
@@ -263,11 +263,9 @@ L.ALS.Helpers = {
 		if (!this.isMobile)
 			return;
 		container.classList.add("als-icon-button-container");
-		for (let el of container.children) {
-			let className = el.getAttribute("data-mobile-class");
-			if (!className)
-				continue;
-			el.className += " " + className;
+		let children = container.querySelectorAll("*[data-mobile-class]");
+		for (let el of children) {
+			el.className += " " + el.getAttribute("data-mobile-class");
 			el[L.ALS.Locales._getElementPropertyToSet(el)] = "";
 			el.removeAttribute("data-als-locale-property");
 		}
@@ -309,6 +307,18 @@ L.ALS.Helpers = {
 	 */
 	isIE11: !(window.ActiveXObject) && "ActiveXObject" in window,
 
+	/**
+	 * If user's browser supports flexbox, will be set to true. Will be false otherwise.
+	 * @type {boolean}
+	 */
+	supportsFlexbox: true,
+
+	/**
+	 * If user's browser is Chrome, will be set to true. Will be false otherwise.
+	 * @type {boolean}
+	 */
+	isChrome: !!window.chrome,
+
 }
 
 /**
@@ -334,6 +344,12 @@ for (let device of devices) {
 }
 L.ALS.Helpers.isMobile = (L.ALS.Helpers.deviceType === "phone");
 document.body.classList.add((L.ALS.Helpers.isMobile) ? "mobile" : "not-mobile");
+
+// Detect flexbox support
+let p = document.createElement("p");
+p.style.display = "flex";
+if (p.style.display !== "flex")
+	L.ALS.Helpers.supportsFlexbox = false;
 
 // Fix font size on mobile devices
 let meta = document.createElement("meta");

--- a/js/LeafletAdvancedLayerSystem/Helpers.js
+++ b/js/LeafletAdvancedLayerSystem/Helpers.js
@@ -262,7 +262,7 @@ L.ALS.Helpers = {
 	_applyButtonsIconsIfMobile: function (container) {
 		if (!this.isMobile)
 			return;
-		container.classList.add("icon-button-container");
+		container.classList.add("als-icon-button-container");
 		for (let el of container.children) {
 			let className = el.getAttribute("data-mobile-class");
 			if (!className)

--- a/js/LeafletAdvancedLayerSystem/Layer.js
+++ b/js/LeafletAdvancedLayerSystem/Layer.js
@@ -114,11 +114,30 @@ L.ALS.Layer = L.ALS.Widgetable.extend({
 		menuButton.className = "ri ri-settings-3-line";
 
 		// Menu itself
-		L.ALS.Helpers.makeHideable(menuButton, this.container, () => {
-			this.container.style.height = "0";
-		}, () => {
-			this.container.style.height = this.container.scrollHeight + "px";
-		});
+
+
+		let hideFn, showFn;
+		// Old chrome can't deal with animations below, so in this case we'll just change display property.
+		if (!L.ALS.Helpers.supportsFlexbox && L.ALS.Helpers.isChrome) {
+			hideFn = () => { this.container.style.display = "none"; };
+			showFn = () => { this.container.style.display = ""; };
+		} else {
+			hideFn = () => {
+				this.container.style.height = this.container.scrollHeight + "px";
+				setTimeout(() => {
+				if (this.container.getAttribute("data-hidden") === "1") // Seems like it prevents bugs when user clicks button continuously
+						this.container.style.height = "0";
+				}, 10); // Wait for height to apply
+			};
+			showFn = () => {
+				this.container.style.height = this.container.scrollHeight + "px";
+				setTimeout(() => {
+					if (this.container.getAttribute("data-hidden") === "0") // Same as above
+						this.container.style.height = "auto";
+				}, 300); // Await animation end
+			}
+		}
+		L.ALS.Helpers.makeHideable(menuButton, this.container, hideFn, showFn);
 
 		// Hide/show button
 		this._hideButton = document.createElement("i");

--- a/js/LeafletAdvancedLayerSystem/Layer.js
+++ b/js/LeafletAdvancedLayerSystem/Layer.js
@@ -51,7 +51,7 @@ L.ALS.Layer = L.ALS.Widgetable.extend({
 	 * @param settings {Object} Settings to pass to `init()`
 	 */
 	initialize: function(layerSystem, args, settings) {
-		L.ALS.Widgetable.prototype.initialize.call(this, "layer-menu");
+		L.ALS.Widgetable.prototype.initialize.call(this, "als-layer-menu");
 		this.setConstructorArguments([args]);
 		this.serializationIgnoreList.push("_layerSystem", "map", "_nameLabel", "layers", "_mapEvents", "getBounds", "isSelected");
 
@@ -81,11 +81,11 @@ L.ALS.Layer = L.ALS.Widgetable.extend({
 		// Build menu
 		// Handle
 		let handle = document.createElement("i");
-		handle.className = "layer-handle ri ri-drag-move-2-line";
+		handle.className = "als-layer-handle ri ri-drag-move-2-line";
 
 		// Editable label containing layer's name
 		let label = document.createElement("p");
-		label.className = "layer-label";
+		label.className = "als-layer-label";
 		label.innerHTML = this.defaultName;
 
 		// Make it editable on double click
@@ -134,11 +134,11 @@ L.ALS.Layer = L.ALS.Widgetable.extend({
 		}, false);
 
 		let layerWidget = document.createElement("div");
-		layerWidget.className = "layer-container";
+		layerWidget.className = "als-layer-container";
 		layerWidget.id = this.id;
 
 		let controlsContainer = document.createElement("div");
-		controlsContainer.className = "controls-row-set";
+		controlsContainer.className = "als-items-row";
 		let elements = [handle, label, menuButton, this._hideButton];
 		for (let e of elements)
 			controlsContainer.appendChild(e);

--- a/js/LeafletAdvancedLayerSystem/System.js
+++ b/js/LeafletAdvancedLayerSystem/System.js
@@ -439,7 +439,6 @@ L.ALS.System = L.Control.extend({
 		try { this._loadProjectWorker(json); }
 		catch (e) {
 			// TODO: Add mechanism to change program name and link to the program's page
-			// TODO: Remove "pre-alpha state" notice when project will come out of alpha state
 			window.alert(L.ALS.systemNotProject);
 			console.log(e);
 		}

--- a/js/LeafletAdvancedLayerSystem/System.js
+++ b/js/LeafletAdvancedLayerSystem/System.js
@@ -159,7 +159,7 @@ L.ALS.System = L.Control.extend({
 		// Make layers sortable. We have to reorder layers when their widgets has been reordered and when map state changes. See _reorderLayers() implementation.
 		// noinspection JSUnusedGlobalSymbols
 		new Sortable(this._layerContainer, {
-			handle: ".layer-handle",
+			handle: ".als-layer-handle",
 			animation: 250,
 			onEnd: () => {
 				this._reorderLayers();
@@ -477,7 +477,7 @@ L.ALS.System = L.Control.extend({
 
 	onAdd: function () {
 		let button = document.createElement("i");
-		button.className = "button-base icon-button ri ri-menu-line als-menu-button";
+		button.className = "als-button-base icon-button ri ri-menu-line als-menu-button";
 		L.ALS.Helpers.makeHideable(button, this.menu);
 
 		let container = document.createElement("div");

--- a/js/LeafletAdvancedLayerSystem/_service/GeneralSettings.js
+++ b/js/LeafletAdvancedLayerSystem/_service/GeneralSettings.js
@@ -23,7 +23,7 @@ L.ALS._service.GeneralSettings = L.ALS.Settings.extend({
 		languageWidget.setAttributes({ defaultValue: "English" });
 
 		// Build theme widget
-		let themeWidget = new L.ALS.Widgets.DropDownList("theme", "generalSettingsTheme", this, "changeTheme");
+		let themeWidget = new L.ALS.Widgets.RadioButtonGroup("theme", "generalSettingsTheme", this, "changeTheme");
 		for (let theme of [this._lightTheme, this._darkTheme])
 			themeWidget.addItem(theme);
 

--- a/js/LeafletAdvancedLayerSystem/_service/GeneralSettings.js
+++ b/js/LeafletAdvancedLayerSystem/_service/GeneralSettings.js
@@ -23,7 +23,7 @@ L.ALS._service.GeneralSettings = L.ALS.Settings.extend({
 		languageWidget.setAttributes({ defaultValue: "English" });
 
 		// Build theme widget
-		let themeWidget = new L.ALS.Widgets.RadioButtonGroup("theme", "generalSettingsTheme", this, "changeTheme");
+		let themeWidget = new L.ALS.Widgets.RadioButtonsGroup("theme", "generalSettingsTheme", this, "changeTheme");
 		for (let theme of [this._lightTheme, this._darkTheme])
 			themeWidget.addItem(theme);
 

--- a/js/LeafletAdvancedLayerSystem/_service/SettingsWindow.js
+++ b/js/LeafletAdvancedLayerSystem/_service/SettingsWindow.js
@@ -27,7 +27,7 @@ L.ALS._service.SettingsWindow = L.ALS._service.SidebarWindow.extend({
 		importButton.addEventListener("click", () => { this.importSettings(); });
 
 		for (let button of [exportButton, importButton]) {
-			button.className = "button-base";
+			button.className = "als-button-base";
 			this.closeButton.parentElement.insertBefore(button, this.closeButton);
 		}
 
@@ -51,7 +51,7 @@ L.ALS._service.SettingsWindow = L.ALS._service.SidebarWindow.extend({
 				throw new Error("Your widget doesn't have attributes.defaultValue set! Pass attributes argument containing value property to widget's constructor.");
 
 			let button = document.createElement("i");
-			button.className = "ri ri-arrow-go-back-line revert-button";
+			button.className = "ri ri-arrow-go-back-line als-revert-button";
 			L.ALS.Locales.localizeElement(button, "settingsRevertButton", "title");
 			widget.container.appendChild(button);
 

--- a/js/LeafletAdvancedLayerSystem/_service/SettingsWindow.js
+++ b/js/LeafletAdvancedLayerSystem/_service/SettingsWindow.js
@@ -53,7 +53,7 @@ L.ALS._service.SettingsWindow = L.ALS._service.SidebarWindow.extend({
 			let button = document.createElement("i");
 			button.className = "ri ri-arrow-go-back-line als-revert-button";
 			L.ALS.Locales.localizeElement(button, "settingsRevertButton", "title");
-			widget.container.appendChild(button);
+			widget.containerForRevertButton.appendChild(button);
 
 			button.addEventListener("click", () => {
 				widget.setValue(widget.attributes.defaultValue);

--- a/js/LeafletAdvancedLayerSystem/_service/SidebarWindow.js
+++ b/js/LeafletAdvancedLayerSystem/_service/SidebarWindow.js
@@ -24,8 +24,8 @@ L.ALS._service.SidebarWindow = L.ALS.WidgetableWindow.extend({
 		<div class="als-window-sidebar-title" data-als-locale-property="${contentTitle}"></div>
 	</div>
 </div>
-<div class="controls-row-set als-sidebar-window-button-container" data-id="buttons-wrapper">
-	<div class="button-base" data-id="close-button" data-mobile-class="ri ri-close-line" data-als-locale-property="${closeButtonTitle}"></div>
+<div class="als-items-row als-sidebar-window-button-container" data-id="buttons-wrapper">
+	<div class="als-button-base" data-id="close-button" data-mobile-class="ri ri-close-line" data-als-locale-property="${closeButtonTitle}"></div>
 </div>
 		`, this.window);
 
@@ -93,7 +93,7 @@ L.ALS._service.SidebarWindow = L.ALS.WidgetableWindow.extend({
 		this.select.appendChild(option);
 
 		let sidebarItem = document.createElement("div");
-		sidebarItem.className = "button-base";
+		sidebarItem.className = "als-button-base";
 		sidebarItem.addEventListener("click", () => {
 			this.displayItem(name);
 		});

--- a/js/LeafletAdvancedLayerSystem/_service/WizardWindow.js
+++ b/js/LeafletAdvancedLayerSystem/_service/WizardWindow.js
@@ -1,7 +1,7 @@
 L.ALS._service.WizardWindow = L.ALS._service.SidebarWindow.extend({
 	initialize: function (button) {
 		L.ALS._service.SidebarWindow.prototype.initialize.call(this, button, "wizardSelectTitle", "wizardContentTitle");
-		this.select.className = "als-wizard-menu";
+		this.select.classList.add("als-wizard-menu");
 
 		let addButton = document.createElement("div");
 		addButton.className = "als-button-base als-wizard-add-button";

--- a/js/LeafletAdvancedLayerSystem/_service/WizardWindow.js
+++ b/js/LeafletAdvancedLayerSystem/_service/WizardWindow.js
@@ -4,7 +4,7 @@ L.ALS._service.WizardWindow = L.ALS._service.SidebarWindow.extend({
 		this.select.className = "als-wizard-menu";
 
 		let addButton = document.createElement("div");
-		addButton.className = "button-base als-wizard-add-button";
+		addButton.className = "als-button-base als-wizard-add-button";
 		addButton.setAttribute("data-mobile-class", "ri ri-check-line");
 		L.ALS.Locales.localizeElement(addButton, "wizardAddButton");
 		this.window.querySelector("div[data-id='buttons-wrapper']").appendChild(addButton);

--- a/js/LeafletAdvancedLayerSystem/_service/markup.js
+++ b/js/LeafletAdvancedLayerSystem/_service/markup.js
@@ -4,17 +4,17 @@ module.exports = `
 <div class="als-menu">
 	<!-- Top panel -->
 	<div class="als-top-panel-wrapper">
-		<div class="controls-row-set als-top-panel">
+		<div class="als-items-row als-top-panel">
 		
-			<i class="button-base ri ri-close-line als-menu-close" data-als-locale-property="menuCloseButton" data-als-locale-property-to-localize="title"></i>
+			<i class="als-button-base ri ri-close-line als-menu-close" data-als-locale-property="menuCloseButton" data-als-locale-property-to-localize="title"></i>
 			
-			<div class="button-base ri ri-save-3-line als-save-button" data-als-locale-property="menuSaveButton" data-als-locale-property-to-localize="title"></div>
+			<div class="als-button-base ri ri-save-3-line als-save-button" data-als-locale-property="menuSaveButton" data-als-locale-property-to-localize="title"></div>
 			
-			<label for="als-load-input" class="button-base ri ri-folder-open-line als-load-button" data-als-locale-property="menuLoadButton" data-als-locale-property-to-localize="title"></label>
+			<label for="als-load-input" class="als-button-base ri ri-folder-open-line als-load-button" data-als-locale-property="menuLoadButton" data-als-locale-property-to-localize="title"></label>
 			
-			<div class="button-base ri ri-share-line als-export-button" data-als-locale-property="menuExportButton" data-als-locale-property-to-localize="title"></div>
+			<div class="als-button-base ri ri-share-line als-export-button" data-als-locale-property="menuExportButton" data-als-locale-property-to-localize="title"></div>
 			
-			<div class="button-base ri ri-sound-module-line als-settings-button" data-als-locale-property="menuSettingsButton" data-als-locale-property-to-localize="title"></div>
+			<div class="als-button-base ri ri-sound-module-line als-settings-button" data-als-locale-property="menuSettingsButton" data-als-locale-property-to-localize="title"></div>
 			
 			<select class="als-menu-maps-select"></select>
 			

--- a/js/LeafletAdvancedLayerSystem/locales/English.js
+++ b/js/LeafletAdvancedLayerSystem/locales/English.js
@@ -16,8 +16,8 @@ L.ALS.Locales["English"] = {
 
 	// Wizard
 
-	wizardSelectTitle: "Select layer type to add",
-	wizardContentTitle: "Set initial layer parameters",
+	wizardSelectTitle: "Layer type to add",
+	wizardContentTitle: "New layer options",
 	wizardAddButton: "Add",
 
 	// Settings

--- a/js/LeafletAdvancedLayerSystem/locales/Russian.js
+++ b/js/LeafletAdvancedLayerSystem/locales/Russian.js
@@ -16,8 +16,8 @@ L.ALS.Locales["Русский"] = {
 
 	// Wizard
 
-	wizardSelectTitle: "Выберите тип слоя для добавления",
-	wizardContentTitle: "Установите изначальные параметры типа слоя",
+	wizardSelectTitle: "Тип слоя для добавления",
+	wizardContentTitle: "Параметры нового слоя",
 	wizardAddButton: "Добавить",
 
 	// Settings

--- a/js/LeafletAdvancedLayerSystem/widgets/BaseWidget.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/BaseWidget.js
@@ -108,9 +108,9 @@ L.ALS.Widgets.BaseWidget = L.ALS.Serializable.extend({
 		for (let event of this.events)
 			this.input.addEventListener(event, (event) => {
 				if (!this.onChange(event))
-					this.input.classList.add("invalid-input");
+					this.input.classList.add("als-invalid-input");
 				else
-					this.input.classList.remove("invalid-input");
+					this.input.classList.remove("als-invalid-input");
 				this.callCallback();
 			});
 

--- a/js/LeafletAdvancedLayerSystem/widgets/BaseWidget.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/BaseWidget.js
@@ -213,9 +213,8 @@ L.ALS.Widgets.BaseWidget = L.ALS.Serializable.extend({
 	 * @param text {string} Text to set. You can also pass locale property to localize the label.
 	 */
 	setLabelText: function (text) {
-		if (!this.labelWidget) // See comment above
-			return;
-		L.ALS.Locales.localizeOrSetValue(this.labelWidget, text);
+		if (this.labelWidget) // See comment above
+			L.ALS.Locales.localizeOrSetValue(this.labelWidget, text);
 	},
 
 });

--- a/js/LeafletAdvancedLayerSystem/widgets/BaseWidget.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/BaseWidget.js
@@ -39,6 +39,7 @@ L.ALS.Widgets.BaseWidget = L.ALS.Serializable.extend({
 		this.callback = callback;
 		this.attributes = attributes;
 		this.container = this.toHtmlElement();
+		this.containerForRevertButton = this.container;
 	},
 
 	/**
@@ -135,10 +136,8 @@ L.ALS.Widgets.BaseWidget = L.ALS.Serializable.extend({
 	 * @param attributes Object containing attributes
 	 */
 	setAttributes: function (attributes) {
-		if (this.input === undefined)
-			return; // In some cases widgets doesn't have an input
 		for (let attr in attributes) {
-			if (attributes.hasOwnProperty(attr))
+			if (this.input && attributes.hasOwnProperty(attr))
 				this.input.setAttribute(attr, attributes[attr]);
 			if (attr === "defaultValue") // Exception for default values
 				this.attributes.defaultValue = attributes[attr];

--- a/js/LeafletAdvancedLayerSystem/widgets/Button.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/Button.js
@@ -1,0 +1,64 @@
+/**
+ * A button. Always takes up the whole width of the container.
+ */
+L.ALS.Widgets.Button = L.ALS.Widgets.BaseWidget.extend({
+
+	customWrapperClassName: "als-buttons-wrapper",
+	undoable: false,
+
+	/**
+	 * Constructs the button
+	 * @param id {string} ID of this input. You can select this object using this ID.
+	 * @param text {string} Text for the button. You can also pass locale property to localize the text.
+	 * @param objectToControl {Object|L.ALS.Serializable} Just pass "this". If you plan to use serialization, this object MUST be instance of L.ALS.Serializable.
+	 * @param callback {string} Name of a method of objectToControl that will be called when button will be pressed.
+	 * @param mobileIcon {string} class appended to this button if user's device is a phone. Can be used for setting an icon instead of text to save up space and avoid word wrapping. You can use Remix Icon classes to do so. Or you can install your own icon pack (not recommended due to inconsistency) and use it this way.
+	 */
+	initialize: function (id, text, objectToControl = undefined, callback = "", mobileIcon = "") {
+		this._mobileIcon = mobileIcon;
+		L.ALS.Widgets.BaseWidget.prototype.initialize.call(this, "", id, "", objectToControl, callback, ["click"], {});
+		this.setButtonText(text);
+		this.setConstructorArguments(arguments);
+	},
+
+	toHtmlElement: function () {
+		let container = this.createContainer();
+		container.appendChild(this._createInput());
+		return container;
+	},
+
+	createInputElement: function () {
+		let button = document.createElement("div");
+		button.className = "als-button-base";
+		if (this._mobileIcon !== "") {
+			button.setAttribute("data-mobile-class", "ri " + this._mobileIcon);
+			this._waitForElementToBeAdded();
+		}
+		return button;
+	},
+
+	/**
+	 * Sets button text
+	 * @param text {string} text to set. Can be a locale property.
+	 */
+	setButtonText: function (text) {
+		L.ALS.Locales.localizeOrSetValue(this.input, text);
+	},
+
+	/**
+	 * @return {string} Button text
+	 */
+	getButtonText: function () {
+		return L.ALS.Locales.getLocalePropertyOrValue(this.input);
+	},
+
+	_waitForElementToBeAdded: async function () {
+		while (!this.container || this.container.parentNode === null)
+			await new Promise(resolve => setTimeout(resolve, 0)); // Infinite loop hangs the script. Timeout prevents it.
+		L.ALS.Helpers._applyButtonsIconsIfMobile(this.container);
+	},
+
+	getValue: function () {},
+	setValue: function () {},
+
+})

--- a/js/LeafletAdvancedLayerSystem/widgets/ButtonsGroup.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/ButtonsGroup.js
@@ -1,0 +1,44 @@
+/**
+ * A group of buttons that will be nicely wrapped if user's browser supports flexboxes or will be displayed as a single column in other browsers.
+ */
+L.ALS.Widgets.ButtonsGroup = L.ALS.Widgets.ItemsWidgetInterface.extend({
+
+	initialize: function (id) {
+		L.ALS.Widgets.BaseWidget.prototype.initialize.call(this, "", id, "");
+		this._items = {};
+	},
+
+	toHtmlElement: function () {
+		let container = this.createContainer();
+		container.classList.add("als-buttons-group-wrapper");
+		return container;
+	},
+
+	/**
+	 * Adds a button to this group. Basically, acts as L.ALS.Widgets.Button factory so it accepts almost all of it's constructor arguments.
+	 * @param item {string} Name and text of the button. You can pass locale property to localize it.
+	 * @param objectToControl {Object|L.ALS.Serializable} Just pass "this". If you plan to use serialization, this object MUST be instance of L.ALS.Serializable.
+	 * @param callback {string} Name of a method of objectToControl that will be called when button will be pressed.
+	 * @param mobileIcon {string} class appended to new button if user's device is a phone. Can be used for setting an icon instead of text to save up space and avoid word wrapping. You can use Remix Icon classes to do so. Or you can install your own icon pack (not recommended due to inconsistency) and use it this way.
+	 */
+	addItem: function (item, objectToControl = undefined, callback = "", mobileIcon = "") {
+		let button = new L.ALS.Widgets.Button(item, item, objectToControl, callback, mobileIcon);
+		this.container.appendChild(button.container);
+		this._items[item] = button;
+	},
+
+	/**
+	 * Finds and returns button in this group
+	 * @param item {string} Name of the button
+	 * @return {L.ALS.Widgets.Button} Found button or undefined if there's no specified button
+	 */
+	getItem: function (item) {
+		return this._items[item];
+	},
+
+	removeItem: function (item) {
+		this.container.removeChild(this._items[item]);
+		delete this._items[item];
+	}
+
+});

--- a/js/LeafletAdvancedLayerSystem/widgets/Checkbox.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/Checkbox.js
@@ -11,12 +11,19 @@ L.ALS.Widgets.Checkbox = L.ALS.Widgets.BaseWidget.extend({
 		this.setValue(false);
 
 		// Build checkbox
+
+	},
+
+	toHtmlElement: function () {
+		let container = this.createContainer();
+		container.appendChild(this._createInput());
 		this.input.className = "hidden";
 		this.visualElement = document.createElement("label");
 		this.visualElement.htmlFor = this.input.id;
-		this.visualElement.className = "als-button-base ri";
+		this.visualElement.className = "als-button-base ri ri-check-line";
 		this.input.parentElement.appendChild(this.visualElement);
-
+		container.appendChild(this.createLabel());
+		return container;
 	},
 
 	getValue: function () {
@@ -29,7 +36,6 @@ L.ALS.Widgets.Checkbox = L.ALS.Widgets.BaseWidget.extend({
 	 */
 	setValue: function (value) {
 		this.input.checked = value;
-		this._updateVisualElement();
 	},
 
 	/**
@@ -47,19 +53,5 @@ L.ALS.Widgets.Checkbox = L.ALS.Widgets.BaseWidget.extend({
 	isChecked: function () {
 		return this.getValue();
 	},
-
-	callCallback: function () {
-		this._updateVisualElement();
-		L.ALS.Widgets.BaseWidget.prototype.callCallback.call(this);
-	},
-
-	_updateVisualElement: function () {
-		if (!this.visualElement) // setValue() is being called at parent's constructor, so we gotta create this check
-			return;
-		if (this.input.checked)
-			this.visualElement.classList.add("ri-check-line");
-		else
-			this.visualElement.classList.remove("ri-check-line");
-	}
 
 });

--- a/js/LeafletAdvancedLayerSystem/widgets/Checkbox.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/Checkbox.js
@@ -20,7 +20,7 @@ L.ALS.Widgets.Checkbox = L.ALS.Widgets.BaseWidget.extend({
 		this.input.className = "hidden";
 		this.visualElement = document.createElement("label");
 		this.visualElement.htmlFor = this.input.id;
-		this.visualElement.className = "als-button-base ri ri-check-line";
+		this.visualElement.className = "ri ri-check-line";
 		this.input.parentElement.appendChild(this.visualElement);
 		container.appendChild(this.createLabel());
 		return container;

--- a/js/LeafletAdvancedLayerSystem/widgets/Checkbox.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/Checkbox.js
@@ -9,6 +9,14 @@ L.ALS.Widgets.Checkbox = L.ALS.Widgets.BaseWidget.extend({
 		L.ALS.Widgets.BaseWidget.prototype.initialize.call(this, "checkbox", id, label, objectToControl, callback, ["change"], {});
 		this.setConstructorArguments(arguments);
 		this.setValue(false);
+
+		// Build checkbox
+		this.input.className = "hidden";
+		this.visualElement = document.createElement("label");
+		this.visualElement.htmlFor = this.input.id;
+		this.visualElement.className = "als-button-base ri";
+		this.input.parentElement.appendChild(this.visualElement);
+
 	},
 
 	getValue: function () {
@@ -21,6 +29,7 @@ L.ALS.Widgets.Checkbox = L.ALS.Widgets.BaseWidget.extend({
 	 */
 	setValue: function (value) {
 		this.input.checked = value;
+		this._updateVisualElement();
 	},
 
 	/**
@@ -28,7 +37,7 @@ L.ALS.Widgets.Checkbox = L.ALS.Widgets.BaseWidget.extend({
 	 * @param isChecked {boolean} Check (true) or uncheck (false) this checkbox
 	 */
 	setChecked: function (isChecked) {
-		this.setChecked(isChecked);
+		this.setValue(isChecked);
 	},
 
 	/**
@@ -37,6 +46,20 @@ L.ALS.Widgets.Checkbox = L.ALS.Widgets.BaseWidget.extend({
 	 */
 	isChecked: function () {
 		return this.getValue();
+	},
+
+	callCallback: function () {
+		this._updateVisualElement();
+		L.ALS.Widgets.BaseWidget.prototype.callCallback.call(this);
+	},
+
+	_updateVisualElement: function () {
+		if (!this.visualElement) // setValue() is being called at parent's constructor, so we gotta create this check
+			return;
+		if (this.input.checked)
+			this.visualElement.classList.add("ri-check-line");
+		else
+			this.visualElement.classList.remove("ri-check-line");
 	}
 
 });

--- a/js/LeafletAdvancedLayerSystem/widgets/DropDownList.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/DropDownList.js
@@ -1,8 +1,5 @@
-L.ALS.Widgets.DropDownList = L.ALS.Widgets.BaseWidget.extend({
+L.ALS.Widgets.DropDownList = L.ALS.Widgets.ItemsWidgetInterface.extend({
 
-	/**
-	 * Constructs DropDownList
-	 */
 	initialize: function (id, label, objectToControl, callback) {
 		L.ALS.Widgets.BaseWidget.prototype.initialize.call(this, "", id, label, objectToControl, callback, ["change"]);
 		this.setConstructorArguments(arguments);
@@ -12,10 +9,6 @@ L.ALS.Widgets.DropDownList = L.ALS.Widgets.BaseWidget.extend({
 		return document.createElement("select");
 	},
 
-	/**
-	 * Adds item to this list
-	 * @param item {string} Content of the item
-	 */
 	addItem: function (item) {
 		let option = document.createElement("option");
 		L.ALS.Locales.localizeOrSetValue(option, item, "text");
@@ -23,10 +16,6 @@ L.ALS.Widgets.DropDownList = L.ALS.Widgets.BaseWidget.extend({
 		this.callCallback();
 	},
 
-	/**
-	 * Removes item from this list, if it exists
-	 * @param item {string} Content of the item
-	 */
 	removeItem: function (item) {
 		for (let child of this.input.childNodes) {
 			if (L.ALS.Locales.getLocalePropertyOrValue(child) === item) {
@@ -36,10 +25,6 @@ L.ALS.Widgets.DropDownList = L.ALS.Widgets.BaseWidget.extend({
 		}
 	},
 
-	/**
-	 * Selects specific item.
-	 * @param item {string} String that you've passed to addItem().
-	 */
 	selectItem: function (item) {
 		// We do this because changing HTMLSelectElement.value doesn't work in IE
 		for (let option of this.input.options) {
@@ -55,10 +40,6 @@ L.ALS.Widgets.DropDownList = L.ALS.Widgets.BaseWidget.extend({
 		if (this.input.selectedIndex === -1)
 			return undefined;
 		return L.ALS.Locales.getLocalePropertyOrValue(this.input.options[this.input.selectedIndex]);
-	},
-
-	setValue: function (value) {
-		this.selectItem(value);
 	},
 
 });

--- a/js/LeafletAdvancedLayerSystem/widgets/File.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/File.js
@@ -15,7 +15,7 @@ L.ALS.Widgets.File = L.ALS.Widgets.BaseWidget.extend({
 		let container = L.ALS.Widgets.BaseWidget.prototype.toHtmlElement.call(this);
 		this.fileArea = document.createElement("label");
 		this.fileArea.htmlFor = this.input.id;
-		this.fileArea.className = "button-base als-file-area";
+		this.fileArea.className = "als-button-base als-file-area";
 		this.input.parentNode.appendChild(this.fileArea);
 		this._updateFileArea();
 		return container;

--- a/js/LeafletAdvancedLayerSystem/widgets/ItemsWidgetInterface.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/ItemsWidgetInterface.js
@@ -1,0 +1,40 @@
+/**
+ * Defines methods for implementing widgets that can have multiple items, for example, drop-down lists and sets of radio buttons.
+ *
+ */
+L.ALS.Widgets.ItemsWidgetInterface = L.ALS.Widgets.BaseWidget.extend({
+
+	/**
+	 * Adds item to this widget
+	 * @param item {string} Text content of the item. Can be a locale property. Use this string to access added item later.
+	 */
+	addItem: function (item) {},
+
+	/**
+	 * Removes item from this widget if it exists
+	 * @param item {string} Item to remove
+	 */
+	removeItem: function (item) {},
+
+	/**
+	 * Selects item if it exists.
+	 * @param item {string} item to select
+	 */
+	selectItem: function (item) {},
+
+	/**
+	 * Alias for `selectItem()`
+	 * @param value {string} Value to set
+	 */
+	setValue: function (value) {
+		this.selectItem(value);
+	},
+
+	/**
+	 * @return {string} Currently selected item's name
+	 */
+	getValue: function () {
+		return "";
+	}
+
+});

--- a/js/LeafletAdvancedLayerSystem/widgets/Number.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/Number.js
@@ -35,11 +35,11 @@ L.ALS.Widgets.Number = L.ALS.Widgets.BaseWidget.extend({
 		}
 
 		let minusButton = document.createElement("div");
-		minusButton.className = "button-base ri ri-subtract-line";
+		minusButton.className = "als-button-base ri ri-subtract-line";
 		minusButton.addEventListener("click", () => { callback(-1); });
 
 		let plusButton = document.createElement("div");
-		plusButton.className = "button-base ri ri-add-line";
+		plusButton.className = "als-button-base ri ri-add-line";
 		plusButton.addEventListener("click", () => { callback(1); });
 
 		let wrapper = this.input.parentNode;

--- a/js/LeafletAdvancedLayerSystem/widgets/RadioButtonGroup.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/RadioButtonGroup.js
@@ -1,0 +1,103 @@
+L.ALS.Widgets.RadioButtonGroup = L.ALS.Widgets.BaseWidget.extend({
+
+	/**
+	 * Constructs DropDownList
+	 */
+	initialize: function (id, label, objectToControl, callback) {
+		L.ALS.Widgets.BaseWidget.prototype.initialize.call(this, "", id, label, objectToControl, callback, ["change"]);
+		this.radioNames = L.ALS.Helpers.generateID();
+		this.containerForRevertButton = this.container.getElementsByClassName("als-radio-label-wrapper")[0];
+		this.setConstructorArguments(arguments);
+	},
+
+	toHtmlElement: function () {
+		let container = this.createContainer();
+		container.classList.add("als-radio-group-wrapper");
+		let labelWrapper = document.createElement("div");
+		labelWrapper.className = "als-radio-label-wrapper";
+		labelWrapper.appendChild(this.createLabel());
+		container.appendChild(labelWrapper);
+		return container;
+	},
+
+	/**
+	 * Adds item to this list
+	 * @param item {string} Content of the item
+	 */
+	addItem: function (item) {
+		let itemWrapper = document.createElement("div");
+		itemWrapper.className = "als-widget-row";
+
+		let radioWrapper = document.createElement("div");
+		radioWrapper.className = "als-input als-checkbox-wrapper";
+
+		let radio = document.createElement("input");
+		radio.type = "radio";
+		radio.name = this.radioNames;
+		radio.id = L.ALS.Helpers.generateID();
+		radio.className = "hidden";
+		radioWrapper.appendChild(radio);
+
+		let radioVisualElement = document.createElement("label");
+		radioVisualElement.htmlFor = radio.id;
+		radioVisualElement.className = "als-button-base ri ri-check-line";
+		radioWrapper.appendChild(radioVisualElement);
+
+		let label = document.createElement("label");
+		label.htmlFor = radio.id;
+		label.className = "als-label";
+		L.ALS.Locales.localizeOrSetValue(label, item);
+
+		radio.addEventListener("change", () => {
+			if (radio.checked)
+				this.callCallback();
+		});
+
+		itemWrapper.appendChild(radioWrapper);
+		itemWrapper.appendChild(label);
+		this.container.appendChild(itemWrapper);
+
+		for (let e of [itemWrapper, radio, label])
+			e.setAttribute("data-radio-id", item);
+
+		this.callCallback();
+	},
+
+	/**
+	 * Removes item from this list, if it exists
+	 * @param item {string} Content of the item
+	 */
+	removeItem: function (item) {
+		let container = this._getContainer(item);
+		if (!container)
+			return;
+		this.container.removeChild(container);
+	},
+
+	/**
+	 * Selects specific item.
+	 * @param item {string} String that you've passed to addItem().
+	 */
+	selectItem: function (item) {
+		let container = this._getContainer(item);
+		if (!container)
+			return;
+		container.getElementsByTagName("input")[0].checked = true;
+	},
+
+	getValue: function () {
+		for (let child of this.container.getElementsByTagName("input")) {
+			if (child.checked)
+				return L.ALS.Locales.getLocalePropertyOrValue(this.container.querySelector(`label[data-radio-id="${child.getAttribute("data-radio-id")}"]`));
+		}
+	},
+
+	setValue: function (value) {
+		this.selectItem(value);
+	},
+
+	_getContainer: function (item) {
+		return this.container.querySelector(`div[data-radio-id="${item}"]`);
+	}
+
+});

--- a/js/LeafletAdvancedLayerSystem/widgets/RadioButtonsGroup.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/RadioButtonsGroup.js
@@ -1,8 +1,5 @@
-L.ALS.Widgets.RadioButtonGroup = L.ALS.Widgets.BaseWidget.extend({
+L.ALS.Widgets.RadioButtonsGroup = L.ALS.Widgets.ItemsWidgetInterface.extend({
 
-	/**
-	 * Constructs DropDownList
-	 */
 	initialize: function (id, label, objectToControl, callback) {
 		L.ALS.Widgets.BaseWidget.prototype.initialize.call(this, "", id, label, objectToControl, callback, ["change"]);
 		this.radioNames = L.ALS.Helpers.generateID();
@@ -20,10 +17,6 @@ L.ALS.Widgets.RadioButtonGroup = L.ALS.Widgets.BaseWidget.extend({
 		return container;
 	},
 
-	/**
-	 * Adds item to this list
-	 * @param item {string} Content of the item
-	 */
 	addItem: function (item) {
 		let itemWrapper = document.createElement("div");
 		itemWrapper.className = "als-widget-row";
@@ -63,10 +56,6 @@ L.ALS.Widgets.RadioButtonGroup = L.ALS.Widgets.BaseWidget.extend({
 		this.callCallback();
 	},
 
-	/**
-	 * Removes item from this list, if it exists
-	 * @param item {string} Content of the item
-	 */
 	removeItem: function (item) {
 		let container = this._getContainer(item);
 		if (!container)
@@ -74,10 +63,6 @@ L.ALS.Widgets.RadioButtonGroup = L.ALS.Widgets.BaseWidget.extend({
 		this.container.removeChild(container);
 	},
 
-	/**
-	 * Selects specific item.
-	 * @param item {string} String that you've passed to addItem().
-	 */
 	selectItem: function (item) {
 		let container = this._getContainer(item);
 		if (!container)
@@ -90,10 +75,6 @@ L.ALS.Widgets.RadioButtonGroup = L.ALS.Widgets.BaseWidget.extend({
 			if (child.checked)
 				return L.ALS.Locales.getLocalePropertyOrValue(this.container.querySelector(`label[data-radio-id="${child.getAttribute("data-radio-id")}"]`));
 		}
-	},
-
-	setValue: function (value) {
-		this.selectItem(value);
 	},
 
 	_getContainer: function (item) {

--- a/js/LeafletAdvancedLayerSystem/widgets/RadioButtonsGroup.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/RadioButtonsGroup.js
@@ -33,7 +33,7 @@ L.ALS.Widgets.RadioButtonsGroup = L.ALS.Widgets.ItemsWidgetInterface.extend({
 
 		let radioVisualElement = document.createElement("label");
 		radioVisualElement.htmlFor = radio.id;
-		radioVisualElement.className = "als-button-base ri ri-check-line";
+		radioVisualElement.className = "ri ri-check-line";
 		radioWrapper.appendChild(radioVisualElement);
 
 		let label = document.createElement("label");

--- a/js/LeafletAdvancedLayerSystem/widgets/Widgets.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/Widgets.js
@@ -1,13 +1,30 @@
 /**
  * Contains widgets to add to `Widgetable`s
  */
-L.ALS.Widgets = {};
+L.ALS.Widgets = {
+	/**
+	 * A simple text input widget
+	 */
+	Text: undefined,
+
+	/**
+	 * Default email input
+	 */
+	Email: undefined,
+
+	/**
+	 * Password input widget
+	 */
+	Password: undefined,
+};
 
 require("./BaseWidget.js");
 require("./Time.js");
+require("./Button.js");
 require("./ItemsWidgetInterface.js");
 require("./DropDownList.js");
 require("./RadioButtonsGroup.js");
+require("./ButtonsGroup.js");
 require("./SimpleLabel.js");
 require("./ValueLabel.js");
 require("./TextArea.js");

--- a/js/LeafletAdvancedLayerSystem/widgets/Widgets.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/Widgets.js
@@ -11,6 +11,7 @@ require("./ValueLabel.js");
 require("./TextArea.js");
 require("./Number.js");
 require("./Checkbox.js");
+require("./RadioButtonGroup.js");
 require("./Divider.js");
 require("./File.js");
 require("./Color.js");

--- a/js/LeafletAdvancedLayerSystem/widgets/Widgets.js
+++ b/js/LeafletAdvancedLayerSystem/widgets/Widgets.js
@@ -5,13 +5,14 @@ L.ALS.Widgets = {};
 
 require("./BaseWidget.js");
 require("./Time.js");
+require("./ItemsWidgetInterface.js");
 require("./DropDownList.js");
+require("./RadioButtonsGroup.js");
 require("./SimpleLabel.js");
 require("./ValueLabel.js");
 require("./TextArea.js");
 require("./Number.js");
 require("./Checkbox.js");
-require("./RadioButtonGroup.js");
 require("./Divider.js");
 require("./File.js");
 require("./Color.js");

--- a/js/MathTools.js
+++ b/js/MathTools.js
@@ -160,11 +160,6 @@ class MathTools {
 	 * @return {*[]|undefined} One of: Array of intersections or, if lines doesn't intersect, undefined
 	 */
 	static linesIntersection(line1, line2) {
-		/*
-		// Stuff for other algorithm, not needed now. TODO: Remove it if there will be no bugs found.
-		let y1 = p11[1], x2 = p12[0], y2 = p12[1], y3 = p21[1], x4 = p22[0], y4 = p22[1];
-		let p12 = line1[0],  p22 = line2[1];
-		 */
 		let p11 = line1[0], p21 = line2[0];
 		let x1 = p11[0], x3 = p21[0];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2122,9 +2122,9 @@
       "dev": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001156",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001156.tgz",
-      "integrity": "sha512-z7qztybA2eFZTB6Z3yvaQBIoJpQtsewRD74adw2UbRWwsRq3jIPvgrQGawBMbfafekQaD21FWuXNcywtTDGGCw==",
+      "version": "1.0.30001214",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
+      "integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==",
       "dev": true
     },
     "node_modules/caseless": {
@@ -12866,9 +12866,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001156",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001156.tgz",
-      "integrity": "sha512-z7qztybA2eFZTB6Z3yvaQBIoJpQtsewRD74adw2UbRWwsRq3jIPvgrQGawBMbfafekQaD21FWuXNcywtTDGGCw==",
+      "version": "1.0.30001214",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
+      "integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==",
       "dev": true
     },
     "caseless": {


### PR DESCRIPTION
Fixed bug in BaseWidget that makes widgets without input throw an exception.
Now checkboxes are positioned left relative to the label as anyone would expect.
Fixed a couple of bugs in checkboxes.
Added radio buttons.
Theme switcher now uses radio buttons instead of drop-down menu.
Added buttons and group of buttons.
Added ItemsWidgetInterface for implementing widgets that can have multiple items. Drop-down lists, radio buttons and buttons groups implement this interface.
Now widgets can specify container for revert button added by the settings.
Fixed wrong layer menu height. Unfortunately, it causes broken animations in old Chrome, so menu now won't be animated in such Chrome versions.
Fixed wrong L.ALS.Helpers.makeHideable() behavior.
Fixed drop-down menus in old browsers.
Fixed layer type menu in wizard window.
Changed the way mobile icons are being applied.
Made wizard labels less verbose.
Removed unnecessary comments from drop-down lists and radio buttons.
Removed outdated TODOs.