### PR TITLE
Bug fixes

### DIFF
--- a/SynthBase/Hull.js
+++ b/SynthBase/Hull.js
@@ -244,7 +244,7 @@ L.ALS.SynthBaseLayer.prototype.connectHullToAirport = function () {
 				continue;
 
 			let [p1, p2] = layer.getLatLngs(),
-				len = totalLength - layer.pathLength + this.getLineLengthMeters([p1, airportPos]) + this.getLineLengthMeters([p2, airportPos]);
+				len = totalLength - layer.pathLength + this.getLineLengthMeters([p1, airportPos, p2]);
 
 			if (len < minLen) {
 				minLen = len;
@@ -266,7 +266,7 @@ L.ALS.SynthBaseLayer.prototype.connectHullToAirport = function () {
 
 		let [p1, p2] = toRemove.getLatLngs();
 		hullConnection.setLatLngs([p1, airportPos, p2]);
-		path.updateWidgets(minLen);
+		path.updateWidgets(minLen + path.hullLength);
 	}
 }
 
@@ -276,6 +276,10 @@ L.ALS.SynthBaseLayer.prototype.connectHullToAirport = function () {
 L.ALS.SynthBaseLayer.prototype.connectHull = function () {
 	for (let i = 0; i < this.paths.length; i++) {
 		let path = this.paths[i];
+		path.hullLength = 0;
+		let layers = path.pathGroup.getLayers();
+		for (let layer of layers)
+			path.hullLength += this.getLineLengthMeters(layer);
 		this._createPathWidget(path, 1, path.toUpdateColors);
 		this.buildHull(path, this.getWidgetById(`color${i}`).getValue());
 	}

--- a/SynthBase/calculateParameters.js
+++ b/SynthBase/calculateParameters.js
@@ -5,7 +5,6 @@ L.ALS.SynthBaseLayer.prototype.calculateParameters = function () {
 	let parameters = ["cameraWidth", "cameraHeight", "pixelWidth", "focalLength", "imageScale", "overlayBetweenPaths", "overlayBetweenImages", "aircraftSpeed"];
 	for (let param of parameters)
 		this[param] = this.getWidgetById(param)?.getValue();
-	this.flightHeight = this["imageScale"] * this["focalLength"];
 
 	let cameraParametersWarning = this.getWidgetById("cameraParametersWarning");
 	if (this["cameraHeight"] > this["cameraWidth"])
@@ -14,7 +13,8 @@ L.ALS.SynthBaseLayer.prototype.calculateParameters = function () {
 		cameraParametersWarning.setValue("");
 
 	let pixelWidth = this["pixelWidth"] * 1e-6;
-	let focalLength = this["focalLength"] * 0.001;
+	let focalLength = this["focalLength"] / 1000;
+	this.flightHeight = this["imageScale"] * focalLength;
 
 	this.ly = this["cameraWidth"] * pixelWidth; // Image size in meters
 	this.Ly = this.ly * this["imageScale"] // Image width on the ground
@@ -29,7 +29,7 @@ L.ALS.SynthBaseLayer.prototype.calculateParameters = function () {
 	this.FOV = turfHelpers.radiansToDegrees(this["cameraWidth"] * this.IFOV / 1e6);
 	this.GFOV = this["cameraWidth"] * this.GSI;
 
-	this.aircraftSpeedInMetersPerSecond = this["aircraftSpeed"] * 1 / 36;
+	this.aircraftSpeedInMetersPerSecond = this["aircraftSpeed"] / 3.6;
 
 	this.timeBetweenCaptures = this.Bx / this.aircraftSpeedInMetersPerSecond;
 

--- a/SynthGeometryLayer/SynthGeometryLayer.js
+++ b/SynthGeometryLayer/SynthGeometryLayer.js
@@ -19,7 +19,18 @@ L.ALS.SynthGeometryLayer = L.ALS.Layer.extend( /** @lends L.ALS.SynthGeometryLay
 		if (wizardResults === "deserialized")
 			return;
 
+		if (!window.FileReader) {
+			this._deleteInvalidLayer(L.ALS.locale.geometryBrowserNotSupported);
+			return;
+		}
+
 		let file = wizardResults["geometryFileLabel"][0], fileReader = new FileReader();
+
+		if (!file) {
+			this._deleteInvalidLayer(L.ALS.locale.geometryNoFileSelected);
+			return;
+		}
+
 		this.setName(file.name);
 
 		// Try to read as shapefile

--- a/SynthGeometryLayer/SynthGeometryWizard.js
+++ b/SynthGeometryLayer/SynthGeometryWizard.js
@@ -9,6 +9,10 @@ L.ALS.SynthGeometryWizard = L.ALS.Wizard.extend( /** @lends L.ALS.SynthGeometryW
 
 	initialize: function () {
 		L.ALS.Wizard.prototype.initialize.call(this);
+		if (!window.FileReader) {
+			this.addWidget(new L.ALS.Widgets.SimpleLabel("lbl", "geometryBrowserNotSupported", "center", "error"));
+			return;
+		}
 		this.addWidget(new L.ALS.Widgets.File("geometryFileLabel", "geometryFileLabel"));
 	}
 

--- a/SynthPolygonLayer/toGeoJSON.js
+++ b/SynthPolygonLayer/toGeoJSON.js
@@ -36,7 +36,7 @@ L.ALS.SynthPolygonLayer.prototype.toGeoJSON = function () {
 
 	jsons.push(L.ALS.SynthBaseLayer.prototype.toGeoJSON.call(this, parallelsProps, meridiansProps));
 
-	let pointsParams = [["capturePointByMeridians", this.latPointsGroup.getLayers()], ["capturePointByParallels", this.lngPointsGroup.getLayers()]];
+	let pointsParams = [["capturePointsByMeridians", this.latPointsGroup.getLayers()], ["capturePointsByParallels", this.lngPointsGroup.getLayers()]];
 	for (let param of pointsParams) {
 		for (let layer of param[1]) {
 			let pointsJson = layer.toGeoJSON();

--- a/locales/English.js
+++ b/locales/English.js
@@ -110,20 +110,22 @@ L.ALS.Locales.addLocaleProperties("English", {
 	rectangleBorderColor: "Rectangle border color:",
 	rectangleFillColor: "Rectangle fill color:",
 
-	// SynthShapefileWizard
+	// SynthGeometryWizard
 
 	geometryDisplayName: "Geometry Layer",
 	geometryFileLabel: "Zipped shapefile or GeoJSON:",
 
-	// SynthShapefileLayer
+	// SynthGeometryLayer
 
 	geometryOutOfBounds: "Features in selected file are out of visible area. Please, check projection and/or add .prj file to the archive.",
 	geometryInvalidFile: "This file is not valid zipped shapefile or GeoJSON file",
 	geometryNoFeatures: "This file doesn't contain any features, so it won't be added",
 	geometryBorderColor: "Border color:",
 	geometryFillColor: "Fill color:",
+	geometryBrowserNotSupported: "Your browser doesn't support adding this layer. You still can open projects with this layer though.",
+	geometryNoFileSelected: "No file has been selected. Please, select a file that you want to add and try again.",
 
-	// Shapefile settings
+	// SynthGeometrySettings
 
 	geometryDefaultFillColor: "Default fill color:",
 	geometryDefaultBorderColor: "Default border color:",

--- a/locales/Russian.js
+++ b/locales/Russian.js
@@ -117,6 +117,8 @@ L.ALS.Locales.addLocaleProperties("Русский", {
 	geometryNoFeatures: "Этот файл не содержит объектов, поэтому не будет добавлен",
 	geometryBorderColor: "Цвет обводки:",
 	geometryFillColor: "Цвет заливки:",
+	geometryBrowserNotSupported: "Ваш браузер не поддерживает добавление данного слоя, но вы можете открывать проекты, использующие этот слой.",
+	geometryNoFileSelected: "Файл не был выбран. Пожалуйста, выберете файл, который хотите добавить, и попробуйте снова.",
 
 	// Shapefile settings
 

--- a/main.js
+++ b/main.js
@@ -12,6 +12,7 @@ require("leaflet-advanced-layer-system");
 L.ALS.Locales.AdditionalLocales.Russian();
 require("./node_modules/leaflet.coordinates/dist/Leaflet.Coordinates-0.1.5.min.js");
 require("leaflet-draw");
+window.type = true; // Fixes L.Draw error. Devs forgot to initialize this variable in their code, and project looks dead, so there will be no fixes from devs.
 require("./locales/English.js");
 require("./locales/Russian.js");
 require("./SynthGeometryLayer/SynthGeometryLayer.js");

--- a/main.js
+++ b/main.js
@@ -8,11 +8,10 @@
 // I've spend hours struggling with this issue, so don't try to reorganise the code, you'll fail and, as it seems, break compatibility with the older Electron versions.
 
 //require("fastestsmallesttextencoderdecoder");
+require("leaflet-draw");
 require("leaflet-advanced-layer-system");
 L.ALS.Locales.AdditionalLocales.Russian();
 require("./node_modules/leaflet.coordinates/dist/Leaflet.Coordinates-0.1.5.min.js");
-require("leaflet-draw");
-window.type = true; // Fixes L.Draw error. Devs forgot to initialize this variable in their code, and project looks dead, so there will be no fixes from devs.
 require("./locales/English.js");
 require("./locales/Russian.js");
 require("./SynthGeometryLayer/SynthGeometryLayer.js");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "synthflight",
-  "version": "0.0.14-alpha",
+  "version": "0.0.15-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "synthflight",
-      "version": "0.0.14-alpha",
+      "version": "0.0.15-alpha",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@electron/remote": "^2.0.1",
-        "leaflet-advanced-layer-system": "^2.1.3"
+        "leaflet-advanced-layer-system": "^2.1.4"
       },
       "devDependencies": {
         "@babel/core": "^7.12.3",
@@ -6021,9 +6021,9 @@
       "dev": true
     },
     "node_modules/leaflet-advanced-layer-system": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/leaflet-advanced-layer-system/-/leaflet-advanced-layer-system-2.1.3.tgz",
-      "integrity": "sha512-TQ/oqL50g12mF+WtKOzvpBVVNKirB1mw7hxyf8woT7U0cAW2uaWVaCwUtge6AVSzMYcNVPDCSJmCt0BFKQsRWQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/leaflet-advanced-layer-system/-/leaflet-advanced-layer-system-2.1.4.tgz",
+      "integrity": "sha512-097PPwHzJ+oVOKV2ul2cMENj3TQ/d5ZFow1wH5n1uLIaDj7j9ZnCuIaRP6f5HO/WTvwaLjRpgUsA7yiO6AhsiQ=="
     },
     "node_modules/leaflet-draw": {
       "version": "1.0.4",
@@ -17523,9 +17523,9 @@
       "dev": true
     },
     "leaflet-advanced-layer-system": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/leaflet-advanced-layer-system/-/leaflet-advanced-layer-system-2.1.3.tgz",
-      "integrity": "sha512-TQ/oqL50g12mF+WtKOzvpBVVNKirB1mw7hxyf8woT7U0cAW2uaWVaCwUtge6AVSzMYcNVPDCSJmCt0BFKQsRWQ=="
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/leaflet-advanced-layer-system/-/leaflet-advanced-layer-system-2.1.4.tgz",
+      "integrity": "sha512-097PPwHzJ+oVOKV2ul2cMENj3TQ/d5ZFow1wH5n1uLIaDj7j9ZnCuIaRP6f5HO/WTvwaLjRpgUsA7yiO6AhsiQ=="
     },
     "leaflet-draw": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "synthflight",
   "productName": "SynthFlight",
-  "version": "0.0.15-alpha",
+  "version": "0.0.16-alpha",
   "description": "A fully client-side software for planning aerial photography",
   "main": "electronApp.js",
   "browser": "index.html",
@@ -95,6 +95,6 @@
   },
   "dependencies": {
     "@electron/remote": "^2.0.1",
-    "leaflet-advanced-layer-system": "^2.1.3"
+    "leaflet-advanced-layer-system": "^2.1.4"
   }
 }


### PR DESCRIPTION
1. Fixed flight height calculation.
1. Fixed km/h to m/s conversion which, in turn, fixes time between captures and flight time.
1. Fixed path length calculation when "All into one" method is used.
1. When exporting, renamed "capturePoint" to "capturePoints".
1. Fixed objects not drawing in Rectangle and Line layers.
1. Geometry layer:
	1. Added a warning that this layer can't be used, if browser doesn't support FileReader.
	1. Added a message when no file has been selected. Previously an error would be thrown.
