### PR TITLE
Reverted to Leaflet 1.7.1, updated ALS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "synthflight",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "synthflight",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@electron/remote": "^2.0.1",
-        "leaflet-advanced-layer-system": "^2.2.9"
+        "leaflet-advanced-layer-system": "^2.2.10"
       },
       "devDependencies": {
         "@babel/core": "^7.12.3",
@@ -39,7 +39,7 @@
         "geotiff-geokeys-to-proj4": "^2022.5.28",
         "http-server": "^0.12.3",
         "keyboardevent-key-polyfill": "^1.1.0",
-        "leaflet": "~1.8.0",
+        "leaflet": "~1.7.1",
         "leaflet-draw": "^1.0.4",
         "leaflet-draw-locales": "^1.2.1",
         "leaflet.coordinates": "~0.1.5",
@@ -6048,15 +6048,15 @@
       }
     },
     "node_modules/leaflet": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.8.0.tgz",
-      "integrity": "sha512-gwhMjFCQiYs3x/Sf+d49f10ERXaEFCPr+nVTryhAW8DWbMGqJqt9G4XuIaHmFW08zYvhgdzqXGr8AlW8v8dQkA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==",
       "dev": true
     },
     "node_modules/leaflet-advanced-layer-system": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/leaflet-advanced-layer-system/-/leaflet-advanced-layer-system-2.2.9.tgz",
-      "integrity": "sha512-z2/MAyrxId6NXVTvQMs93iS3pskYgfGi2j1i9mPKu2fgKEklPfCCv2W0GJDg8aG0aCE9nB1ym9TNs+EDPV/Q3g=="
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/leaflet-advanced-layer-system/-/leaflet-advanced-layer-system-2.2.10.tgz",
+      "integrity": "sha512-BwNnvVa/fTZN+T96PmJ3ahCcWB7uo4B52wyQbLDa6uAm4YdSbHVrzTxe52s8wH9AdeDwGPktSr9T0aK4wWfGuQ=="
     },
     "node_modules/leaflet-draw": {
       "version": "1.0.4",
@@ -17592,15 +17592,15 @@
       }
     },
     "leaflet": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.8.0.tgz",
-      "integrity": "sha512-gwhMjFCQiYs3x/Sf+d49f10ERXaEFCPr+nVTryhAW8DWbMGqJqt9G4XuIaHmFW08zYvhgdzqXGr8AlW8v8dQkA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw==",
       "dev": true
     },
     "leaflet-advanced-layer-system": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/leaflet-advanced-layer-system/-/leaflet-advanced-layer-system-2.2.9.tgz",
-      "integrity": "sha512-z2/MAyrxId6NXVTvQMs93iS3pskYgfGi2j1i9mPKu2fgKEklPfCCv2W0GJDg8aG0aCE9nB1ym9TNs+EDPV/Q3g=="
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/leaflet-advanced-layer-system/-/leaflet-advanced-layer-system-2.2.10.tgz",
+      "integrity": "sha512-BwNnvVa/fTZN+T96PmJ3ahCcWB7uo4B52wyQbLDa6uAm4YdSbHVrzTxe52s8wH9AdeDwGPktSr9T0aK4wWfGuQ=="
     },
     "leaflet-draw": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "scripts": {
-    "start": "electron electronApp.js -d",
+    "start": "electron electronApp.js",
     "postinstall": "npm link leaflet-advanced-layer-system",
     "serve": "http-server \"./dist/SynthFlight-browser\" -c-1",
     "build": "node build.js",
@@ -80,7 +80,7 @@
     "geotiff-geokeys-to-proj4": "^2022.5.28",
     "http-server": "^0.12.3",
     "keyboardevent-key-polyfill": "^1.1.0",
-    "leaflet": "~1.8.0",
+    "leaflet": "~1.7.1",
     "leaflet-draw": "^1.0.4",
     "leaflet-draw-locales": "^1.2.1",
     "leaflet.coordinates": "~0.1.5",
@@ -101,6 +101,6 @@
   },
   "dependencies": {
     "@electron/remote": "^2.0.1",
-    "leaflet-advanced-layer-system": "^2.2.9"
+    "leaflet-advanced-layer-system": "^2.2.10"
   }
 }


### PR DESCRIPTION
Leaflet 1.8.0 introduced lags when moving markers and tooltips when drawing mode is activated